### PR TITLE
Add newline to jq join side note

### DIFF
--- a/src/content/jq-intro/steps/Step2.md
+++ b/src/content/jq-intro/steps/Step2.md
@@ -58,6 +58,6 @@ And you can use `[]` to get all the elements in the array. For example, here is 
 
     The `-j` option (for join) can combine together your output.
 
-    <Execute command={`echo '["1","2","3"]' | jq -j '.[]'`} />
+    <Execute command={`echo '["1","2","3","\n"]' | jq -j '.[]'`} />
 
 </Alert>


### PR DESCRIPTION
First of all love what you've built- I've been recommending it to folks. Very nit PR here regarding how the absence of a newline in the `jq -j` side note returns the result followed immediately by the next prompt (image depicts it better).

![image](https://github.com/sandbox-bio/sandbox.bio/assets/13989647/07e45d07-1e05-4d0a-82ad-7d4f93aec361)
