### PR TITLE
Fix potential crash in progress store due to missing user check

### DIFF
--- a/src/stores/progress.js
+++ b/src/stores/progress.js
@@ -8,7 +8,7 @@ export const progress = writable({});
 // When tutorial progress is updated, update DB
 progress.subscribe(async (newProgress) => {
 	const userInfo = get(user);
-	if (!browser || !userInfo.id) return;
+	if (!browser || !userInfo || !userInfo.id) return;
 	const query = supabaseAnon.from(t("state")).update({ progress: newProgress }).match({ user_id: userInfo.id });
 
 	const { error } = await query;


### PR DESCRIPTION
The `progress.subscribe` callback attempted to access `userInfo.id` without ensuring `userInfo` itself was not null or undefined. This could happen if the user session is cleared, leading to a runtime error when accessing properties of null. Added a null check for `userInfo` before accessing its ID.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.