### PR TITLE
docs(fqgrep-intro): clarify interleaved paired output on Page 6

### DIFF
--- a/src/content/fqgrep-intro/steps/Step6.md
+++ b/src/content/fqgrep-intro/steps/Step6.md
@@ -14,7 +14,7 @@ fqgrep's `--paired` flag treats input files as paired. When a pattern matches in
 
 <Execute command={`fqgrep --paired 'AGATCGGAAGAGC' reads_R1.fastq reads_R2.fastq | head -24`} />
 
-Notice the output alternates between R1 and R2 reads (interleaved), keeping pairs together.
+Both mates of a pair share the same read name (as in real paired FASTQ), so each name appears **twice in a row** — first the R1 mate, then its R2 mate. The sequences differ even though the names match. You can confirm this in the colored example below: within a pair, the adapter is highlighted in R1 but not in its R2 mate.
 
 ## Counting paired matches
 


### PR DESCRIPTION
Page 6 (Paired-End Reads) told readers to "notice the output alternates between R1 and R2 reads (interleaved)." The output is correct interleaved FASTQ — for each matching pair, R1 is written immediately followed by its R2 — but both mates of a pair share the same read name (as in real paired FASTQ), so the alternation isn't visible from the header lines alone. Running the `head -24` example, the first block of matches all carry the `_R1adapter` tag on both mates, so it looks like only R1 records are present.

This rewrites that one note to describe what's actually on screen: each read name appears twice in a row (the R1 mate, then its R2 mate) with differing sequences, and points to the `--color always` example just below as visual confirmation (the adapter is highlighted in R1 but not in its R2 mate).

Content-only change; no data regeneration, and no exercise validations or planted counts are affected. Verified against fqgrep v1.1.2 (the version the tutorial targets) run on the tutorial's own `data/` files.